### PR TITLE
Fix Hyperlink in 2022-11-04-dignity.md

### DIFF
--- a/_books/2022-11-04-dignity.md
+++ b/_books/2022-11-04-dignity.md
@@ -12,7 +12,7 @@ previous two presentations (each of which is ~1 hour long):
 * About "sorry for being a burden":
   <https://protesilaos.com/books/2022-10-31-sorry-for-being-burden/>.
 * On the meaning and purpose of life:
-  https://protesilaos.com/books/2022-11-02-meaning-purpose-life/.
+  <https://protesilaos.com/books/2022-11-02-meaning-purpose-life/>.
 
 It is not necessary to watch the previous two, as I summarise the
 points relevant to dignity.  Though you may still want to watch or


### PR DESCRIPTION
While the first hyperlink of the previous presentations is working on the website, the second one wasn't. Likely because of the missing < and >