### PR TITLE
Fix 2023-11-25-emacs-denote-org-dynamic-blocks.md

### DIFF
--- a/_codelog/2023-11-25-emacs-denote-org-dynamic-blocks.md
+++ b/_codelog/2023-11-25-emacs-denote-org-dynamic-blocks.md
@@ -2,7 +2,7 @@
 title: "Emacs: Denote Org dynamic blocks"
 excerpt: "Video demonstration on how to use Denote's Org dynamic blocks facility to consolidate your thoughts on a given topic."
 layout: vlog
-mediaid: ""zzXcav0yb50
+mediaid: "zzXcav0yb50"
 ---
 
 In this video I demonstrate Denote's Org dynamic blocks facility. I


### PR DESCRIPTION
This should fix the media link for the YouTube video. Currently, the website looks like this:

![image](https://github.com/protesilaos/my-website/assets/111225446/1c58261f-9217-4e03-8974-4d57b00b4522)
