### PR TITLE
Remove deprecated frame-specific effects doc from fontaine.html

### DIFF
--- a/_pages/emacs/fontaine.html
+++ b/_pages/emacs/fontaine.html
@@ -237,15 +237,8 @@ among the available presets. When called from Lisp, it requires a
 </div>
 
 <p>
-The default behaviour of <code>fontaine-set-preset</code> is to change fonts across
-all graphical frames.  The user can, however, limit the changes to a
-given frame.  For interactive use, this is done by invoking the command
-with a universal prefix argument (<code>C-u</code> by default), which changes fonts
-only in the current frame.  When used in Lisp, the FRAME argument can be
-a frame object (satisfies <code>framep</code>) or a non-nil value: the former
-applies the effects to the given object, while the latter means the
-current frame and thus is the same as interactively supplying the prefix
-argument.
+<code>fontaine-set-preset</code> changes fonts across all graphical
+frames.
 </p>
 
 <p>


### PR DESCRIPTION
Frame-specific effects were removed in 3.0.0: https://protesilaos.com/emacs/fontaine-changelog#h:a8cd979f-851f-4e97-ae90-96022b4cfe7a